### PR TITLE
Add Story Island link to navigation header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,6 +25,9 @@
               <a href="https://contenthospital.org" class="nav__link" target="_blank">Content Hospital</a>
             </li>
             <li class="nav__item">
+              <a href="https://bainbridgebarn.org/storyisland/" class="nav__link" target="_blank">Story Island</a>
+            </li>
+            <li class="nav__item">
               <a href="/contact-me" class="nav__link">Contact Me</a>
             </li>
             <li class="nav__icon nav__icon-search ion ion-md-search"></li>


### PR DESCRIPTION
## Summary
Added a new navigation link to Story Island in the header navigation menu.

## Changes
- Added a new navigation item linking to https://bainbridgebarn.org/storyisland/
- Link opens in a new tab (target="_blank")
- Positioned between the Content Hospital and Contact Me navigation items
- Uses existing nav__item and nav__link styling classes for consistency

## Details
The new link follows the same HTML structure and styling conventions as other external navigation links in the header, ensuring visual and functional consistency with the existing navigation menu.

https://claude.ai/code/session_016JzaNVLfSNS5fZDGL3FbDv